### PR TITLE
fix imports for `InputLine` component from lively.next

### DIFF
--- a/studio/inputs/date.cp.js
+++ b/studio/inputs/date.cp.js
@@ -1,7 +1,8 @@
 import { signal } from 'lively.bindings/index.js';
 import { component, ViewModel, part, ensureFont } from 'lively.morphic/components/core.js';
-import { InputLine, Morph, TilingLayout, Icon, ShadowObject, Label } from 'lively.morphic';
+import { Morph, TilingLayout, Icon, ShadowObject, Label } from 'lively.morphic';
 import { Color, rect, pt } from 'lively.graphics/index.js';
+import {InputLine } from 'lively.components/inputs.js';
 
 import { arr, date } from 'lively.lang/index.js';
 import { galyleoFont } from '../shared.cp.js';

--- a/studio/inputs/slider.cp.js
+++ b/studio/inputs/slider.cp.js
@@ -2,7 +2,8 @@ import { Morph } from 'lively.morphic/morph.js';
 import { pt, rect, Color } from 'lively.graphics/index.js';
 import { signal, connect } from 'lively.bindings/index.js';
 import { component, ViewModel, part } from 'lively.morphic/components/core.js';
-import { Label, TilingLayout, ShadowObject, InputLine, Icon } from 'lively.morphic';
+import { Label, TilingLayout, ShadowObject, Icon } from 'lively.morphic';
+import {InputLine } from 'lively.components/inputs.js';
 
 export class SliderModel extends ViewModel {
   /*


### PR DESCRIPTION
We recently moved the `InputLine` in lively.next (https://github.com/LivelyKernel/lively.next/pull/729). This PR should adapt your imports accordingly.