### PR TITLE
Update package.json with current lively.next version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   },
   "lively": {
     "projectDependencies": [ ],
-    "boundLivelyVersion": "b7cabbc9511e607fecc2b611ccaf88772bc84e69"
+    "boundLivelyVersion": "5cecb8d2030617b92320cefc9ea4e63439e36630"
   }
 }


### PR DESCRIPTION
@merryman previously inserted a lively verison hash manually. However, this one was from a branch that no longer exists. Therefore, opening the dashboard project will always report a version conflict and display a warning.

Using this hash will fix this and will bring this project back to the normal versioning workflow intended for projects.

