### PR TITLE
Add build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build Project
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout lively.next
+        uses: actions/checkout@v3
+        with:
+          repository: LivelyKernel/lively.next
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '18.12.1'
+      - name: Install lively.next
+        run: |
+          chmod a+x ./install.sh
+          ./install.sh
+      - name: Checkout Project Repository
+        uses: actions/checkout@v3
+        with:
+          path: local_projects/engageLively--galyleo-dashboard
+      - name: Build Dashboard
+        run: npm run build --prefix local_projects/engageLively--galyleo-dashboard
+      - name: Upload Build Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build
+          path: local_projects/engageLively--galyleo-dashboard/bin
+            


### PR DESCRIPTION
This adds a GitHub Action that builds the project and afterwards uploads the build as an artifact to GitHub.

The build needs to be triggered manually:

![image](https://github.com/engageLively/galyleo-dashboard/assets/14252419/a1088d3b-f857-43ca-9a3d-872d945acba9)

After running the action, you can click on the run and download the build:

![image](https://github.com/engageLively/galyleo-dashboard/assets/14252419/e4dbd11d-694c-4193-b4e2-9c06bae16781)

This currently will always use the latest version of lively.next and just run `npm run build`. If you need something else or would like more options for anything, feel free to reach out, I am sure we find a solution :)