### PR TITLE
Adapt to new topbar UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,7 @@
     "test": "mocha -r esm galyleo-data/galyleo-data-tests.js"
   },
   "lively": {
-    "projectDependencies": [
-      {
-        "name": "LivelyKernel--partsbin",
-        "version": "0.6.3"
-      }
-    ],
+    "projectDependencies": [],
     "boundLivelyVersion": "6a89749513b773c0e01c023d221cc8a9cab7e931",
     "canUsePages": true
   }

--- a/studio/top-bar.cp.js
+++ b/studio/top-bar.cp.js
@@ -187,7 +187,7 @@ const GalyleoTopBar = component(TopBar, {
             paddingTop: '2px'
           }],
           tooltip: 'Publish this dashboard'
-        }), without('save button'), without('undo button'), without('redo button'), without('open component browser'), without('load world button'), without('comment browser button'), without('canvas mode button'), add({
+        }), without('save button'), without('undo button'), without('redo button'), without('open component browser'), without('load world button'), without('open asset browser'), without('comment browser button'), without('canvas mode button'), add({
           type: Image,
           name: 'galyleo logo',
           borderColor: Color.rgb(23, 160, 251),
@@ -200,7 +200,7 @@ const GalyleoTopBar = component(TopBar, {
         }, 'hand or halo mode button')
       ]
     },
-    without('user flap')
+    without('right UI wrapper')
   ]
 });
 


### PR DESCRIPTION
We recently restructured the top-bar UI partially. This PR contains the necessary changes for the studio-top-bar to not be affected by this.

Also, @rickmcgeer downloading this project via lively will not work right now for the average user, as the code imports `config.js`, which only exists on your system and is put on the `.gitignore`. Just letting you know.